### PR TITLE
add CI to build latex

### DIFF
--- a/.github/workflows/build-latex.yml
+++ b/.github/workflows/build-latex.yml
@@ -1,0 +1,18 @@
+name: Build LaTeX document
+on: [push]
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v4
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: main.tex
+          latexmk_use_lualatex: true
+      - name: Upload PDF file
+        uses: actions/upload-artifact@v4
+        with:
+          name: PDF
+          path: main.pdf


### PR DESCRIPTION
adds CI that builds pdf on push

prevents visitors that just want to see the pdf from needing to clone repo and build it themselves (while still preventing the need to track the pdf in the git repo)

optionally this could be added:
- on tagged commits: upload a pdf as a github release