### PR TITLE
CI: fix bibliography / missing submodule

### DIFF
--- a/.github/workflows/build-latex.yml
+++ b/.github/workflows/build-latex.yml
@@ -13,11 +13,13 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v4
+        with:
+          submodules: 'true'
       - name: Compile LaTeX document
         uses: xu-cheng/latex-action@v3
         with:
           root_file: main.tex
-          latexmk_use_lualatex: true
+          latexmk_use_lualatex: false
       - name: Upload PDF file
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
since the submodule wasn't checked out, the pdf built by the CI didn't have proper bibliography.
this fixes it

for the difference see the two releases/pdfs on my branch: https://github.com/uzantome/ccpScript/releases